### PR TITLE
[sublimetext4] Add subl.exe shim, improve package

### DIFF
--- a/automatic/sublimetext4/tools/chocolateyInstall.ps1
+++ b/automatic/sublimetext4/tools/chocolateyInstall.ps1
@@ -1,14 +1,16 @@
 ﻿$ErrorActionPreference = 'Stop'
 
+$packageName = $env:ChocolateyPackageName
+$softwareName = 'Sublime Text'
+
 $packageArgs = @{
-  packageName            = 'sublimetext4'
+  packageName            = $packageName
   fileType               = 'exe'
   url                    = 'https://download.sublimetext.com/sublime_text_build_4145_x64_setup.exe'
   checksum               = '42e50b59c5ae6d803a6ac87ccf12b0d215572bfdfc39b8f9448085b6f97d290c'
   checksumType           = 'sha256'
   silentArgs             = '/VERYSILENT /NORESTART /TASKS="contextentry"'
   validExitCodes         = @(0)
-  softwareName           = 'Sublime Text 4'
 }
 
 Install-ChocolateyPackage @packageArgs

--- a/automatic/sublimetext4/tools/chocolateyInstall.ps1
+++ b/automatic/sublimetext4/tools/chocolateyInstall.ps1
@@ -14,3 +14,19 @@ $packageArgs = @{
 }
 
 Install-ChocolateyPackage @packageArgs
+
+[array]$key = Get-UninstallRegistryKey -SoftwareName $softwareName
+
+if ($key.Count -eq 1) {
+  $key | ForEach-Object {
+    $sublInstallLocation = Join-Path -Path $_.InstallLocation -ChildPath 'subl.exe'
+    Install-BinFile -Name 'subl' -Path $sublInstallLocation
+  }
+} elseif ($key.Count -eq 0) {
+  Write-Error "$packageName installation failed, unable to detect uninstall registry key."
+  Write-Warning "Please report this to the package maintainer."
+} elseif ($key.Count -gt 1) {
+  Write-Error "$packageName installation failed, multiple ($($key.Count)) uninstall registry keys found."
+  Write-Warning "Please inform the package maintainer that the following keys were matched:"
+  $key | ForEach-Object { Write-Warning "- $($_.DisplayName): $($_.InstallLocation)" }
+}

--- a/automatic/sublimetext4/tools/chocolateyUninstall.ps1
+++ b/automatic/sublimetext4/tools/chocolateyUninstall.ps1
@@ -1,26 +1,26 @@
-$ErrorActionPreference = 'Stop'
+﻿$ErrorActionPreference = 'Stop'
 
-$packageName = "sublimetext4"
+$packageName = $env:ChocolateyPackageName
+$softwareName = 'Sublime Text'
 
-[array]$key = Get-UninstallRegistryKey -SoftwareName "Sublime Text 4"
+[array]$key = Get-UninstallRegistryKey -SoftwareName $softwareName
 
 if ($key.Count -eq 1) {
   $key | ForEach-Object {
     $packageArgs = @{
-      packageName = $packageName
-      fileType    = 'exe'
-      silentArgs  = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /TASKS="contextentry"'
-      validExitCodes= @(0)
-      file          = "$($_.UninstallString.Trim('"'))"
+      packageName    = $packageName
+      fileType       = 'exe'
+      silentArgs     = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /TASKS="contextentry"'
+      validExitCodes = @(0)
+      file           = "$($_.UninstallString.Trim('"'))"
+      softwareName   = $softwareName
     }
- 
     Uninstall-ChocolateyPackage @packageArgs
   }
 } elseif ($key.Count -eq 0) {
   Write-Warning "$packageName has already been uninstalled by other means."
 } elseif ($key.Count -gt 1) {
-  Write-Warning "$($key.Count) matches found!"
-  Write-Warning "To prevent accidental data loss, no programs will be uninstalled."
-  Write-Warning "Please alert package maintainer the following keys were matched:"
-  $key | ForEach-Object {Write-Warning "- $($_.DisplayName)"}
+  Write-Error "$packageName uninstallation failed, multiple ($($key.Count)) uninstall registry keys found."
+  Write-Warning "Please inform the package maintainer that the following keys were matched:"
+  $key | ForEach-Object { Write-Warning "- $($_.DisplayName): $($_.InstallLocation)" }
 }

--- a/automatic/sublimetext4/tools/chocolateyUninstall.ps1
+++ b/automatic/sublimetext4/tools/chocolateyUninstall.ps1
@@ -1,5 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'
 
+Uninstall-BinFile -Name 'subl'
+
 $packageName = $env:ChocolateyPackageName
 $softwareName = 'Sublime Text'
 


### PR DESCRIPTION
Hopefully will address [Jackenmen/choco-auto/issues/6](https://github.com/Jackenmen/choco-auto/issues/6)

- Add: call ShimGen for subl.exe, so you can now use it via CLI.

- Bug: Properly detect Sublime Text uninstaller registry keys.  Sublime Text 4 registry key has been named 'Sublime Text_is1' ever since they switch to Inno Setup installer.  Older Sublime Text installs (3.x and pre-InnoSetup-4.x) might have other registry keys though.  As such, key off of 'Sublime Text*' (to match all possibilities).  Note: this fix is needed for the subl.exe ShimGen to work correctly!

- Bug: No need for 90% of chocolateyUninstall.ps1 given the introduction of Chocolatey's Auto Uninstaller (enabled since Chocolatey 0.9.10). If a user has disabled feature, then they probably don't want the uninstaller running anyway.